### PR TITLE
Images minimization and rearrangement

### DIFF
--- a/src/greatwall/gui.py
+++ b/src/greatwall/gui.py
@@ -1022,7 +1022,13 @@ class GreatWallGui(QMainWindow):
                 if idx == 0:
                     selection_button = widgets
                 else:
-                    flow_layout, selection_group, view, show_hide_button, selection_button = widgets
+                    (
+                        flow_layout,
+                        selection_group,
+                        view,
+                        show_hide_button,
+                        selection_button,
+                    ) = widgets
 
                     image = QPixmap.fromImage(
                         view.rgb_array_to_Qimage(
@@ -1252,12 +1258,8 @@ class GreatWallGui(QMainWindow):
             self.level_down_signal.emit()
 
     def on_selection_show_hide_button_click(
-            self,
-            flow_layout,
-            selection_group,
-            selection_button,
-            selection_view
-        ):
+        self, flow_layout, selection_group, selection_button, selection_view
+    ):
         if selection_view.isVisible():
             flow_layout.insertItem(-1, selection_group)
         else:

--- a/src/greatwall/gui.py
+++ b/src/greatwall/gui.py
@@ -103,6 +103,14 @@ class FlowLayout(QLayout):
         return None
 
     def insertWidget(self, idx, widget):
+        """Insert widget `widget` at specific index `idx` in the widgets list.
+
+        If the index `idx` equals to -1 this method will add the widget at the
+        end of widgets list.
+
+        If the widget is already exist this method will remove the widget from
+        current position and insert it at the index `idx`.
+        """
         self._item_list = [i for i in self._item_list if i.widget() != widget]
         if idx == -1:
             self._item_list.insert(len(self._item_list), QWidgetItem(widget))

--- a/src/greatwall/gui.py
+++ b/src/greatwall/gui.py
@@ -1040,10 +1040,14 @@ class GreatWallGui(QMainWindow):
                     show_hide_button.clicked.connect(
                         lambda
                             state,
+                            flow_layout=flow_layout,
+                            selection_group=selection_group,
                             button=show_hide_button,
                             widget=view,
                         :
                             self.on_selection_show_hide_button_click(
+                                flow_layout,
+                                selection_group,
                                 button,
                                 widget,
                             )
@@ -1249,9 +1253,16 @@ class GreatWallGui(QMainWindow):
 
     def on_selection_show_hide_button_click(
             self,
+            flow_layout,
+            selection_group,
             selection_button,
             selection_view
         ):
+        if selection_view.isVisible():
+            flow_layout.insertItem(-1, selection_group)
+        else:
+            flow_layout.insertItem(0, selection_group)
+
         selection_view.setVisible(not selection_view.isVisible())
 
         button_text = "Hide Image" if selection_view.isVisible() else "Show Image"

--- a/src/greatwall/gui.py
+++ b/src/greatwall/gui.py
@@ -93,13 +93,6 @@ class FlowLayout(QLayout):
     def addItem(self, item):
         self._item_list.append(item)
 
-    def insertItem(self, idx, item):
-        self._item_list = [i for i in self._item_list if i.widget() != item]
-        if idx == -1:
-            self._item_list.insert(len(self._item_list), QWidgetItem(item))
-        else:
-            self._item_list.insert(idx, QWidgetItem(item))
-
     def count(self):
         return len(self._item_list)
 
@@ -108,6 +101,13 @@ class FlowLayout(QLayout):
             return self._item_list[index]
 
         return None
+
+    def insertWidget(self, idx, widget):
+        self._item_list = [i for i in self._item_list if i.widget() != widget]
+        if idx == -1:
+            self._item_list.insert(len(self._item_list), QWidgetItem(widget))
+        else:
+            self._item_list.insert(idx, QWidgetItem(widget))
 
     def takeAt(self, index):
         if 0 <= index < len(self._item_list):
@@ -1261,9 +1261,9 @@ class GreatWallGui(QMainWindow):
         self, flow_layout, selection_group, selection_button, selection_view
     ):
         if selection_view.isVisible():
-            flow_layout.insertItem(-1, selection_group)
+            flow_layout.insertWidget(-1, selection_group)
         else:
-            flow_layout.insertItem(0, selection_group)
+            flow_layout.insertWidget(0, selection_group)
 
         selection_view.setVisible(not selection_view.isVisible())
 

--- a/src/greatwall/gui.py
+++ b/src/greatwall/gui.py
@@ -441,9 +441,9 @@ class GreatWallGui(QMainWindow):
         self.password_text = QTextEdit(self)
 
         # Hardcode to fast tests
-        self.password_text.setText(
-            "viboniboasmofiasbrchsprorirerugugucavehistmiinciwibowifltuor"
-        )
+        # self.password_text.setText(
+        #     "viboniboasmofiasbrchsprorirerugugucavehistmiinciwibowifltuor"
+        # )
 
         # Lists of input widgets
         self.input_state_widgets_list = [


### PR DESCRIPTION
This PR implement the minimization and rearrangement feature of fractal images.

In regard to fractal-images rearrangement, this PR implements a simple approach that moves the image to be the last image when `Hide Image` button is clicked and moves the image to be the first image when `Show Image` button is clicked.

The detailed description of this feature request can be found in ticket #43 in issues section. The following is a screen record to the PR in action.

https://github.com/Yuri-SVB/Great_Wall/assets/50509521/35c02aa4-4224-403a-af56-b188fee0fe96

This PR will may address some issues in the following:
- [x] #43 
- [x] #47