### PR TITLE
Fix docs links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -72,9 +72,7 @@ pip install -r requirements.txt
 cd Great_Wall/src/greatwall/
 python3 gui.py
 ```
-> **_NOTE:_** The previously described method to run app is not the recommend
-one, but as we still in the development cycle this is the simplest way
-to get things ready :).
+> **_NOTE:_** The previously described method to run app is not the recommend one, but as we still in the development cycle this is the simplest way to get things ready :).
 
 ### Using in Beta
 Coming soon. An advanced, knowledgeable, tech-savvy reader, will, at this point, have understood what is to come and can improvise the steps by themselves. In a nutshell, all you have to do is to securely manage[^1] a brute-force resistant `SA0`, true-randomly generate a path vector of `L_i`'s, and memorize them procedurally as explained in the session above. For better effect, user can implement non-trivial **T**ime-**L**ock **P**uzzle, to impose desired time on derivation of `SA3` from `SA0`. To prevent leakage of critical content through Anki, a simple scheme with salt and pepper can be done so to avoid the need to modify Anki, but we'll leave this for a next time.

--- a/docs/pitches/elevator_pitch.md
+++ b/docs/pitches/elevator_pitch.md
@@ -1,19 +1,11 @@
 # Great Wall elevator pitch
 
-In order to fulfill the promise of allowing commoners to _"be their own banks"_, Bitcoin infrastructure has to enable even 
-**low-tech individuals** provide themselves bank levels of security in the broad sense, which include **physical security**.
+In order to fulfill the promise of allowing commoners to _"be their own banks"_, Bitcoin infrastructure has to enable even **low-tech individuals** provide themselves bank levels of security in the broad sense, which include **physical security**.
 
-The (still) relatively early stage of Bitcoinization of global economy provides early-adopters the benefit of 
-[obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity). Long-term solutions to be adopted by the masses 
-are, however, by definition transparent.
+The (still) relatively early stage of Bitcoinization of global economy provides early-adopters the benefit of [obscurity](https://en.wikipedia.org/wiki/Security_through_obscurity). Long-term solutions to be adopted by the masses are, however, by definition transparent.
 
-By logic, therefore, the **centuries old, ubiquitously accepted [doctrine of non-obscurity](https://en.wikipedia.org/wiki/Kerckhoffs%27s_principle) will prevale** 
-and non-obscure security measures eventually **will be the norm**. Great Wall is the first such non-obscure protocol for 
-coercion-resistance in self-custody. It happens to be **monetizable** through the employment of cutting-edge cryptographic techniques like [Fully 
-Homomorphic Encryption](https://www.ibm.com/topics/homomorphic-encryption).
+By logic, therefore, the **centuries old, ubiquitously accepted [doctrine of non-obscurity](https://en.wikipedia.org/wiki/Kerckhoffs%27s_principle) will prevale** and non-obscure security measures eventually **will be the norm**. Great Wall is the first such non-obscure protocol for coercion-resistance in self-custody. It happens to be **monetizable** through the employment of cutting-edge cryptographic techniques like [Fully Homomorphic Encryption](https://www.ibm.com/topics/homomorphic-encryption).
 
-As of the time of writing, we already have the public, formal backing of the protocol by respected names of Bitcoin community 
-and ongoing communication with potential investors.
+As of the time of writing, we already have the public, formal backing of the protocol by respected names of Bitcoin community and ongoing communication with potential investors.
 
-For further information, check out our [demo](https://mega.nz/file/vfwhRTwZ#sP3hSRthQNssWRdcmD8XRNIeJX7Eq174ImY4eva_Pwo), our [official site](https://linktr.ee/greatwallt3) and 
-our [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md).
+For further information, check out our [demo](https://mega.nz/file/vfwhRTwZ#sP3hSRthQNssWRdcmD8XRNIeJX7Eq174ImY4eva_Pwo), our [official site](https://linktr.ee/greatwallt3) and our [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md).

--- a/docs/pitches/startup_pitch.md
+++ b/docs/pitches/startup_pitch.md
@@ -1,8 +1,6 @@
 # Great Wall startup pitch
 
-Great Wall is an elaborate key derivation scheme that yields a unique combination of information security properties through the exploitation 
-of existing cryptographic techniques together with our proposed concept of **T**KBA or **T**acit 
-[Knowledge-Based Authentication](https://en.wikipedia.org/wiki/Knowledge-based_authentication). The following are our achieved properties:
+Great Wall is an elaborate key derivation scheme that yields a unique combination of information security properties through the exploitation of existing cryptographic techniques together with our proposed concept of **T**KBA or **T**acit [Knowledge-Based Authentication](https://en.wikipedia.org/wiki/Knowledge-based_authentication). The following are our achieved properties:
 
 1. **Self-Custody** --- It's the basic premise of Bitcoin: The owner, and the owner alone is able to perform the protocol of access to their funds;
 2. **Non-Obscurity** --- Another way to enunciate the [**Kerckhoff's Principle**](https://en.wikipedia.org/wiki/Kerckhoffs's_principle), or *The adversary perfectly understands the protocol, and it works nevertheless.* Reasons why it is **critically important** are discussed in the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md);
@@ -17,9 +15,7 @@ Our method can be summarized as consisting of two basic components: the decades-
 [memory-hard hashes / key-deriving functions](https://en.wikipedia.org/wiki/Argon2)), and our proposed concept of **T**KBA, or 
 **Tacit** **K**owledge-**B**ased **A**authentication.
 
-The former, TLP, makes sure the scheme takes an arbitrarily long time Delta T of a few hours, days, or even weeks, where such delay is previously 
-setup by the user. Well established cryptographic techniques --- more about that on the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md) --- are 
-used to make sure even an adversary with expensive machinery cannot crack this lengthy Delta T into a few minutes.
+The former, TLP, makes sure the scheme takes an arbitrarily long time Delta T of a few hours, days, or even weeks, where such delay is previously setup by the user. Well established cryptographic techniques --- more about that on the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md) --- are used to make sure even an adversary with expensive machinery cannot crack this lengthy Delta T into a few minutes.
 
 The latter, TKBA, makes sure the legit user's participation is **strictly necessary** for the completion of the derivation scheme. as a consequence,
 
@@ -27,9 +23,6 @@ The latter, TKBA, makes sure the legit user's participation is **strictly necess
 
 If such Delta T has been setup to be long enough, such coercive operation becomes unfeasible and, hence, user has defended themself against physical robbery.
 
-Monetization is possible through the *secure* outsourcing of TLP by user to the provider of such service. In other words, user pays for the convenience 
-of freeing up their devices from the burden of having an intensive, memory hard, hours-, days- or weeks-long computation by *anonymously* paying a web-service 
-to perform it to them.
+Monetization is possible through the *secure* outsourcing of TLP by user to the provider of such service. In other words, user pays for the convenience of freeing up their devices from the burden of having an intensive, memory hard, hours-, days- or weeks-long computation by *anonymously* paying a web-service to perform it to them.
 
-For further information, check out [our demo](https://mega.nz/file/vfwhRTwZ#sP3hSRthQNssWRdcmD8XRNIeJX7Eq174ImY4eva_Pwo), [our official site](https://linktr.ee/greatwallt3) and 
-our [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md).
+For further information, check out [our demo](https://mega.nz/file/vfwhRTwZ#sP3hSRthQNssWRdcmD8XRNIeJX7Eq174ImY4eva_Pwo), [our official site](https://linktr.ee/greatwallt3) and our [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md).

--- a/docs/pitches/startup_pitch.md
+++ b/docs/pitches/startup_pitch.md
@@ -5,11 +5,11 @@ of existing cryptographic techniques together with our proposed concept of **T**
 [Knowledge-Based Authentication](https://en.wikipedia.org/wiki/Knowledge-based_authentication). The following are our achieved properties:
 
 1. **Self-Custody** --- It's the basic premise of Bitcoin: The owner, and the owner alone is able to perform the protocol of access to their funds;
-2. **Non-Obscurity** --- Another way to enunciate the [**Kerckhoff's Principle**](https://en.wikipedia.org/wiki/Kerckhoffs's_principle), or *The adversary perfectly understands the protocol, and it works nevertheless.* Reasons why it is **critically important** are discussed in the [executive summary / white paper](../background/executive_summary.md);
+2. **Non-Obscurity** --- Another way to enunciate the [**Kerckhoff's Principle**](https://en.wikipedia.org/wiki/Kerckhoffs's_principle), or *The adversary perfectly understands the protocol, and it works nevertheless.* Reasons why it is **critically important** are discussed in the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md);
 3. **Devicelessness** --- Loss, destruction, geographic separation, theft or threat to any (external) device doesn't interfere with the protocol;
 4. **Monetization** --- Hence why a startup pitch;
 5. **Coercion-Resistance** --- The main value propostition: how to utilize cryptographic techniques to resist to *physical violence*;
-6. **No Unintended Negative Incentives** --- There is no material incentive to assassinate victim as a way to commit the stealing itself. It stems directly from item 2 and, once again, details at the [executive summary / white paper](../background/executive_summary.md);
+6. **No Unintended Negative Incentives** --- There is no material incentive to assassinate victim as a way to commit the stealing itself. It stems directly from item 2 and, once again, details at the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md);
 7. **Interoperabiltiy** --- The protocol can be used on top of other protocols like **multi-signature schemes** and **inheritance protocols**;
 
 Our method can be summarized as consisting of two basic components: the decades-old concept of 
@@ -18,7 +18,7 @@ Our method can be summarized as consisting of two basic components: the decades-
 **Tacit** **K**owledge-**B**ased **A**authentication.
 
 The former, TLP, makes sure the scheme takes an arbitrarily long time Delta T of a few hours, days, or even weeks, where such delay is previously 
-setup by the user. Well established cryptographic techniques --- more about that on the [executive summary / white paper](../background/executive_summary.md) --- are 
+setup by the user. Well established cryptographic techniques --- more about that on the [executive summary / white paper](../white_paper_executive_summary/white_paper_executive_summary.md) --- are 
 used to make sure even an adversary with expensive machinery cannot crack this lengthy Delta T into a few minutes.
 
 The latter, TKBA, makes sure the legit user's participation is **strictly necessary** for the completion of the derivation scheme. as a consequence,

--- a/docs/white_paper_executive_summary/white_paper_executive_summary.md
+++ b/docs/white_paper_executive_summary/white_paper_executive_summary.md
@@ -17,7 +17,7 @@ As of the moment for writing, the *still* relatively small *(but ever more rapid
       *I do have Bitcoin, but, in order to access it, we would have to first go to that difficult-to-get-address where a certain hardware containing a secret key is located, and / or have to authenticate myself to trusted third parties and prove beyond reasonable doubt I'm not under coercion* --- When that is actually false;
 Finally, there is the following non-passive defense which is, nevertheless obscure:
 5. **Obscurely Cancellable Transaction**: Consists of having a transaction be time-locked, and, before maturity, possible to be reversed. Victim pretends to cooperate with adversary, and, upon release from adversary's custody enacts abortion of transaction done under coercion.
-    
+
 Every case from items 1 to 3 above is but circumstantially true, due only to either insufficient spread of adoption of Bitcoin or insufficient diffusion of knowledge about Bitcoin itself or about techniques and practices to secure it or ignorance by the adversary about the methods in use. Said shortly:
 
 > *All the passive lines of defense cited above are consequence of obscurity and, as such, violate Kerckhoff's principle and grow weaker with the inevitable diffusion of knowledge.*
@@ -33,7 +33,8 @@ The attentive reader may, at this point, pose the argument that *actually deploy
 * **Shared Custody**: Depending on a TTP to either check you for coercion and deny you access to your funds if coercion is detected or suspected or to own physical addresses where physical keys are distributed kills, or, at the very least seriously weakens the premise of **self-custody**. We should also mention...
 * **Questionable Efficacy**: What are the premises that such ceremony for negative proof of coercion has to have to render it mostly effective? Namely: the adversary can always contemplate threatening to kill or brutalize victim to convince TTP to cooperate. What conditions are really sufficient to preclude that? Will those conditions not fall back to two previous problems? In the case of physical distribution of keys: How far apart the remote locations of physical keys have to be from each other to make it unfeasible for a coerced owner visit one by one at gun point during a flash kidnap? Finally, there is the problem of...
 * **Downsides of PBA**: Comparing **K**nowlege-**B**ased **A**uthentication with **P**ossession-**B**ased **A**uthentication becomes easy by starting from the following truism:
-> *One's brain is one's most available and closely guarded hardware.*
+
+    > *One's brain is one's most available and closely guarded hardware.*
 
 Securely physically distributing keys obviously imposes the cost of reliably monitoring its physical security remotely. Then there are the costs associating to setting up, resetting and updating that physical infrastructure ie.: consider the implications of traveling or relocating for such scheme. With that scheme, user makes his property less available to themself depending on their location. Finally, threatening to destroy or render unavailable an external device that is critical for the completion of a protocol, can be used as a negotiation leverage by an adversary to coerce victim into doing *favors of various sorts* or formal transfer of properties that require intensive intervention, like real state. If the only critical 'device' is victim's own brain, and if the latter has an inheritance protocol in place --- more about that later --- the Bitcoin patrimony itself is no longer a surface of coercive attack.
 


### PR DESCRIPTION
This PR simply fix reference links to `white_paper_executive_summary` and fix some formatting typos in docs.