### PR TITLE
Support for using the internal file system based in volatile memory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pycparser==2.21
 PyQt5==5.15.10
 PyQt5-Qt5==5.15.2
 PyQt5-sip==12.13.0
+fs==2.4.16
+cryptography=42.0.5

--- a/src/greatwall/resources/constants.py
+++ b/src/greatwall/resources/constants.py
@@ -64,3 +64,10 @@ MANDELBROT = "mandelbrot"
 BURNING_SHIP = "burningship"
 
 FRACTAL_FUNCTIONS = [MANDELBROT, BURNING_SHIP]
+
+###############################################################################
+# File Extensions
+###############################################################################
+
+EXTENSION_FRACTAL = '.fractal.bin'
+

--- a/src/greatwall/resources/greatwall.py
+++ b/src/greatwall/resources/greatwall.py
@@ -2,13 +2,16 @@ import random
 from typing import Optional
 
 from argon2 import low_level
+from fs.memoryfs import MemoryFS
 
 from .knowledge.fractal import Fractal
 from .knowledge.mnemonic.mnemonic import Mnemonic
 from .knowledge.shaper import Shaper
 
-
 class GreatWall:
+
+    EXTENSION_FRACTAL = '.fractal.bin'
+
     def __init__(self, tacit_knowledge_type: str = "Formosa"):
 
         self.tacit_knowledge_type = tacit_knowledge_type.lower()
@@ -48,6 +51,9 @@ class GreatWall:
         self.state: bytes = self.sa0
         self.shuffled_bytes: bytes = self.sa0  # dummy initialization
         self.current_level: int = 0
+
+        # file system based in volatile memory (RAM)
+        self.memory_file_system = MemoryFS()
 
     def cancel_execution(self):
         self.is_canceled = True
@@ -234,3 +240,23 @@ class GreatWall:
             self.is_finished = False
         self.current_level -= 1
         self.state = self.protocol_states[self.current_level]
+
+    def memory_file_system_data_load(self, name):
+
+        try:
+            virtual_file = self.memory_file_system.openbin(name, 'r')
+            data = virtual_file.read()
+            return data
+        except Exception:
+            return None
+
+    def memory_file_system_data_name(self, key, extension):
+
+        name = f'{ key }{ extension }'
+        return name
+
+    def memory_file_system_data_save(self, name, data):
+
+        virtual_file = self.memory_file_system.openbin(name, 'w')
+        virtual_file.write(data)
+        virtual_file.close()

--- a/src/greatwall/resources/greatwall.py
+++ b/src/greatwall/resources/greatwall.py
@@ -10,8 +10,6 @@ from .knowledge.shaper import Shaper
 
 class GreatWall:
 
-    EXTENSION_FRACTAL = '.fractal.bin'
-
     def __init__(self, tacit_knowledge_type: str = "Formosa"):
 
         self.tacit_knowledge_type = tacit_knowledge_type.lower()

--- a/src/greatwall/test_memory_file_system.py
+++ b/src/greatwall/test_memory_file_system.py
@@ -1,0 +1,30 @@
+from greatwall.resources.greatwall import GreatWall
+from greatwall.resources import constants
+
+def test_memory_file_system():
+
+    greatwall = GreatWall()
+
+    properties = dir(greatwall)
+    assert('memory_file_system' in properties)
+    assert('memory_file_system_data_load' in properties)
+    assert('memory_file_system_data_name' in properties)
+    assert('memory_file_system_data_save' in properties)
+
+    key_fractal = '0,0,1,0'
+    name_fractal = greatwall.memory_file_system_data_name(
+        key_fractal,
+        constants.EXTENSION_FRACTAL,
+    )
+
+    blob_fractal = greatwall.memory_file_system_data_load(name_fractal)
+    assert(blob_fractal is None)
+
+    blob_fractal = b'ABCDEFG'
+    greatwall.memory_file_system_data_save(name_fractal, blob_fractal)
+
+    load_fractal = blob_fractal = greatwall.memory_file_system_data_load(name_fractal)
+    assert(blob_fractal == load_fractal)
+
+
+


### PR DESCRIPTION
This pull request add some features that enable other parts of the code to save and load data from a file system that only resides in memory, thus addressing the issue #50 of storing data in non-volatile memory (hard disk, solid-state drive).

The following test exemplifies how the code is used:
```Python
from greatwall.resources.greatwall import GreatWall

def test_memory_file_system():

    greatwall = GreatWall()

    properties = dir(greatwall)
    assert('memory_file_system' in properties)
    assert('memory_file_system_data_load' in properties)
    assert('memory_file_system_data_name' in properties)
    assert('memory_file_system_data_save' in properties)

    key_fractal = '0,0,1,0'
    name_fractal = greatwall.memory_file_system_data_name(
        key_fractal,
        GreatWall.EXTENSION_FRACTAL,
    )

    blob_fractal = greatwall.memory_file_system_data_load(name_fractal)
    assert(blob_fractal is None)

    blob_fractal = b'ABCDEFG'
    greatwall.memory_file_system_data_save(name_fractal, blob_fractal)

    load_fractal = blob_fractal = greatwall.memory_file_system_data_load(name_fractal)
    assert(blob_fractal == load_fractal)
```

Nothing changes visually, so there are no need for screenshots or recordings.